### PR TITLE
chore: add extension to CONTRIBUTING and LICENSE links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Each package has its own `package.json` file and defines its dependencies, havin
 
 Pull requests are welcome! For major changes, please open an issue first to discuss what you would like to change.
 
-Please read the [CONTRIBUTING](CONTRIBUTING) file to know what we expect from your contribution and the guidelines you should follow.
+Please read the [CONTRIBUTING](CONTRIBUTING.md) file to know what we expect from your contribution and the guidelines you should follow.
 
 ## About
 
@@ -48,4 +48,4 @@ Blackout-react-native is a project maintained by some awesome [contributors](htt
 
 ## License
 
-[MIT](LICENSE) @ Farfetch
+[MIT](LICENSE.md) @ Farfetch

--- a/packages/react-native-analytics/README.md
+++ b/packages/react-native-analytics/README.md
@@ -128,8 +128,8 @@ await analytics.setConsent({
 
 Pull requests are welcome! For major changes, please open an issue first to discuss what you would like to change.
 
-Please read the [CONTRIBUTING](../../CONTRIBUTING) file to know what we expect from your contribution and the guidelines you should follow.
+Please read the [CONTRIBUTING](../../CONTRIBUTING.md) file to know what we expect from your contribution and the guidelines you should follow.
 
 ## License
 
-[MIT](../../LICENSE) @ Farfetch
+[MIT](../../LICENSE.md) @ Farfetch

--- a/packages/react-native-metro-transformer/README.md
+++ b/packages/react-native-metro-transformer/README.md
@@ -39,8 +39,8 @@ Configure the transformer for your app:
 
 Pull requests are welcome! For major changes, please open an issue first to discuss what you would like to change.
 
-Please read the [CONTRIBUTING](../../CONTRIBUTING) file to know what we expect from your contribution and the guidelines you should follow.
+Please read the [CONTRIBUTING](../../CONTRIBUTING.md) file to know what we expect from your contribution and the guidelines you should follow.
 
 ## License
 
-[MIT](../../LICENSE) @ Farfetch
+[MIT](../../LICENSE.md) @ Farfetch

--- a/packages/react-native-riskified-integration/README.md
+++ b/packages/react-native-riskified-integration/README.md
@@ -87,8 +87,8 @@ If no session token is provided, `user.localId` is used instead and this value w
 
 Pull requests are welcome! For major changes, please open an issue first to discuss what you would like to change.
 
-Please read the [CONTRIBUTING](../../CONTRIBUTING) file to know what we expect from your contribution and the guidelines you should follow.
+Please read the [CONTRIBUTING](../../CONTRIBUTING.md) file to know what we expect from your contribution and the guidelines you should follow.
 
 ## License
 
-[MIT](../../LICENSE) @ Farfetch
+[MIT](../../LICENSE.md) @ Farfetch


### PR DESCRIPTION
## Description

This just adds the extension to CONTRIBUTING and LICENSE links in documentation.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)