### PR TITLE
fix(react-native-analytics): fix integration imports

### DIFF
--- a/packages/react-native-analytics/README.md
+++ b/packages/react-native-analytics/README.md
@@ -18,9 +18,11 @@ npm i @farfetch/blackout-react-native-analytics
 
 ### Peer dependencies
 
-Make sure that you have installed the correct Farfetch's peer dependencies:
+Make sure that you have installed the correct peer dependencies of this package:
 
 - [`@farfetch/blackout-core`](https://www.npmjs.com/package/@farfetch/blackout-core)
+- [`@react-native-firebase/analytics`](https://www.npmjs.com/package/@react-native-firebase/analytics) (Only necessary if you need to use Firebase integration).
+- `react-native-forter` (Only necessary if you need to use Forter integration. Contact Forter to know how to install this package as it is not public.)
 
 ## Usage
 

--- a/packages/react-native-analytics/src/integrations/Forter/Forter.js
+++ b/packages/react-native-analytics/src/integrations/Forter/Forter.js
@@ -1,4 +1,3 @@
-import { forterSDK, ForterAccountType } from 'react-native-forter';
 import { Platform } from 'react-native';
 
 import defaultTo from 'lodash/defaultTo';
@@ -30,6 +29,26 @@ import {
   USER_AGENT,
 } from './constants';
 
+let forterSDK;
+let ForterAccountType;
+
+try {
+  const reactNativeForter = require('react-native-forter');
+  forterSDK = reactNativeForter.forterSDK;
+  ForterAccountType = reactNativeForter.ForterAccountType;
+} catch (er) {
+  forterSDK = null;
+  ForterAccountType = null;
+}
+
+function checkRNForterInstalled() {
+  if (!forterSDK) {
+    throw new Error(
+      '[Forter]: "react-native-forter" package is not installed. Please, make sure you have this dependency installed before using this integration.',
+    );
+  }
+}
+
 /**
  * Forter integration for analytics that uses react-native-forter to communicate
  * events to Forter servers.
@@ -50,12 +69,18 @@ import {
 class Forter extends integrations.Integration {
   /**
    * Creates an instance of Forter integration.
+   * Will throw an error if the peer dependency react-native-forter
+   * is not installed.
+   *
+   * @throws
    *
    * @param {object} options - User configured options.
    * @param {object} loadData - analytics's load event data.
    * @param {object} analytics - Stripped down analytics instance with helper methods.
    */
   constructor(options, loadData, analytics) {
+    checkRNForterInstalled();
+
     const safeOptions = defaultTo(options, {});
 
     super(safeOptions, loadData, analytics);

--- a/packages/react-native-analytics/src/integrations/Forter/__tests__/Forter.test.js
+++ b/packages/react-native-analytics/src/integrations/Forter/__tests__/Forter.test.js
@@ -90,6 +90,18 @@ describe('Forter', () => {
     ).toBeInstanceOf(Forter);
   });
 
+  it('Should throw an error if "react-native-forter" is not installed', () => {
+    jest.resetModules();
+
+    jest.doMock('react-native-forter', () => undefined);
+
+    const FreshForterIntegration = require('../Forter').default;
+
+    expect(() => FreshForterIntegration.createInstance()).toThrow(
+      '[Forter]: "react-native-forter" package is not installed. Please, make sure you have this dependency installed before using this integration.',
+    );
+  });
+
   describe('Options Validations', () => {
     it(`Should throw an error if '${OPTION_SITE_ID}' is not specified in options`, () => {
       expect(() =>

--- a/packages/react-native-analytics/src/integrations/Forter/utils/defaultActionCommandBuilder.js
+++ b/packages/react-native-analytics/src/integrations/Forter/utils/defaultActionCommandBuilder.js
@@ -1,6 +1,14 @@
-import { ForterActionType } from 'react-native-forter';
-
 import eventTypes from '../../../eventTypes';
+
+let ForterActionType;
+
+try {
+  ForterActionType = require('react-native-forter').ForterActionType;
+} catch (e) {
+  // Set it to a default object so it does not throw when importing and
+  // react-native-forter is not installed.
+  ForterActionType = {};
+}
 
 const eventTypesMap = {
   [eventTypes.PRODUCT_ADDED_TO_CART]: ForterActionType.ADD_TO_CART,

--- a/packages/react-native-analytics/src/integrations/Forter/utils/defaultNavigationCommandBuilder.js
+++ b/packages/react-native-analytics/src/integrations/Forter/utils/defaultNavigationCommandBuilder.js
@@ -1,9 +1,16 @@
-import get from 'lodash/get';
-import { ForterNavigationType } from 'react-native-forter';
-
 import { utils } from '@farfetch/blackout-core/analytics';
-
+import get from 'lodash/get';
 import screenTypes from '../../../screenTypes';
+
+let ForterNavigationType;
+
+try {
+  ForterNavigationType = require('react-native-forter').ForterNavigationType;
+} catch (e) {
+  // Set it to a default object so it does not throw when importing and
+  // react-native-forter is not installed.
+  ForterNavigationType = {};
+}
 
 /**
  * Default screen types mappings to ForterNavigationType enumeration.

--- a/packages/react-native-analytics/src/integrations/firebaseAnalytics/FirebaseAnalytics.js
+++ b/packages/react-native-analytics/src/integrations/firebaseAnalytics/FirebaseAnalytics.js
@@ -1,6 +1,5 @@
 import get from 'lodash/get';
 import pick from 'lodash/pick';
-import firebaseAnalytics from '@react-native-firebase/analytics';
 import {
   integrations,
   trackTypes as analyticsTrackTypes,
@@ -10,9 +9,28 @@ import { buildMapper, formatEvent, formatUserTraits } from './utils';
 import { eventsMapper } from './mapper';
 import { LOGIN_METHOD, USER_PROPERTIES } from './constants';
 
+let firebaseAnalytics;
+
+try {
+  firebaseAnalytics = require('@react-native-firebase/analytics').default;
+} catch (er) {
+  firebaseAnalytics = null;
+}
+
+function checkRNFirebaseAnalyticsInstalled() {
+  if (!firebaseAnalytics) {
+    throw new Error(
+      '[FirebaseAnalytics]: "@react-native-firebase/analytics" package is not installed. Please, make sure you have this dependency installed before using this integration.',
+    );
+  }
+}
 class FirebaseAnalytics extends integrations.Integration {
   /**
    * Creates an instance of firebase Analytics integration (Google Analytics).
+   * Will throw an error if the peer dependency @react-native-firebase/analytics
+   * is not installed.
+   *
+   * @throws
    *
    * @param {Object} options - User configured options.
    * @param {Object} loadData - analytics's load event data.
@@ -20,6 +38,8 @@ class FirebaseAnalytics extends integrations.Integration {
    * @memberof FirebaseAnalytics#
    */
   constructor(options, loadData) {
+    checkRNFirebaseAnalyticsInstalled();
+
     super(options, loadData);
 
     this.lastUserId = null;
@@ -78,7 +98,7 @@ class FirebaseAnalytics extends integrations.Integration {
 
     if (customOnSetUser && typeof customOnSetUser !== 'function') {
       utils.logger.error(
-        'Firebase Analytics - TypeError: "onSetUser" is not a function. If you are passing a custom "onSetUser" property to the integration, make sure you are passing a valid function.',
+        '[FirebaseAnalytics] TypeError: "onSetUser" is not a function. If you are passing a custom "onSetUser" property to the integration, make sure you are passing a valid function.',
       );
 
       return this;
@@ -181,8 +201,7 @@ class FirebaseAnalytics extends integrations.Integration {
 
     if (typeof eventMapperFn !== 'function') {
       utils.logger.error(
-        `Firebase Analytics - TypeError: Event mapping for event "${event}" is not a function.
-        If you're passing a custom event mapping for this event, make sure a function is passed.`,
+        `[FirebaseAnalytics] TypeError: Event mapping for event "${event}" is not a function. If you're passing a custom event mapping for this event, make sure a function is passed.`,
       );
 
       return this;
@@ -192,8 +211,7 @@ class FirebaseAnalytics extends integrations.Integration {
 
     if (properties && typeof properties !== 'object') {
       utils.logger.error(
-        `Firebase Analytics - TypeError: The properties passed for event ${event} is not an object. If you are passing a custom event mapping for this event,
-        make sure you return a valid object under "properties" key.`,
+        `[FirebaseAnalytics] TypeError: The properties passed for event ${event} is not an object. If you are passing a custom event mapping for this event, make sure you return a valid object under "properties" key.`,
       );
 
       return this;
@@ -204,7 +222,7 @@ class FirebaseAnalytics extends integrations.Integration {
 
       if (!firebaseAnalyticsMethod) {
         utils.logger.error(
-          `Firebase analytics method "${firebaseAnalyticsMethod}" it not defined. If you are passing a custom event mapping, make sure you return a supported Firebase Analytics event.`,
+          `[FirebaseAnalytics] Method "${method}" is not defined. If you are passing a custom event mapping, make sure you return a supported Firebase Analytics event.`,
         );
 
         return this;

--- a/packages/react-native-analytics/src/integrations/firebaseAnalytics/index.js
+++ b/packages/react-native-analytics/src/integrations/firebaseAnalytics/index.js
@@ -1,1 +1,1 @@
-export { default } from './firebaseAnalytics';
+export { default } from './FirebaseAnalytics';

--- a/packages/react-native-analytics/src/integrations/index.js
+++ b/packages/react-native-analytics/src/integrations/index.js
@@ -1,7 +1,14 @@
 import { integrations } from '@farfetch/blackout-core/analytics';
 import AnalyticsService from './AnalyticsService';
 import FirebaseAnalytics from './firebaseAnalytics';
+import Forter from './Forter';
 
 const { Integration, Omnitracking } = integrations;
 
-export { AnalyticsService, FirebaseAnalytics, Integration, Omnitracking };
+export {
+  AnalyticsService,
+  FirebaseAnalytics,
+  Forter,
+  Integration,
+  Omnitracking,
+};


### PR DESCRIPTION
## Description

- This fix react-native-analytics importing strategy that
  would crash the app if a peer dependency of an unused
  integration was not installed. With this fix, the peer
  dependencies that are necessary for some integrations are
  required and checked at runtime only when they are added
  to analytics through `analytics.addIntegration` method.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)