### PR TITLE
fix(react-native-riskified-integration): fix wrong import in Riskified

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,8 @@ module.exports = {
   // A map from regular expressions to module names that allow to stub out resources with a single module
   moduleNameMapper: {
     '^@farfetch/blackout-core(.*)$': '@farfetch/blackout-core/src$1',
+    '^@farfetch/blackout-react-native-analytics(.*)$':
+      '@farfetch/blackout-react-native-analytics/src$1',
   },
   // A preset that is used as a base for Jest's configuration
   preset: 'react-native',

--- a/packages/react-native-riskified-integration/src/Riskified.js
+++ b/packages/react-native-riskified-integration/src/Riskified.js
@@ -1,14 +1,14 @@
 import {
   eventTypes,
-  integrations,
   trackTypes,
   utils,
 } from '@farfetch/blackout-react-native-analytics';
+import Integration from '@farfetch/blackout-react-native-analytics/integrations/integration';
 import { NativeModules, Platform } from 'react-native';
 import get from 'lodash/get';
 
 const { RiskifiedIntegration } = NativeModules;
-export default class Riskified extends integrations.Integration {
+export default class Riskified extends Integration {
   /**
    * Returns true due to being a required integration - No need to check for consent.
    *

--- a/packages/react-native-riskified-integration/src/__tests__/Riskified.test.js
+++ b/packages/react-native-riskified-integration/src/__tests__/Riskified.test.js
@@ -22,24 +22,13 @@ jest.mock('react-native', () => ({
   },
 }));
 
-// NOTE: We need to create a mock for @farfetch/blackout-react-native-analytics
-//       because if not, an error will occur when importing @farfetch/blackout-react-native-analytics
-//       with firebase that is imported there. To circumvent it,
-//       we create a mock of react-native-analytics by using @farfetch/blackout-core module.
-//       Do not use requireActual with @farfetch/blackout-react-native-analytics as it will
-//       raise the problem as well.
 jest.mock('@farfetch/blackout-react-native-analytics', () => {
-  const originalAnalyticsCore = jest.requireActual(
-    '@farfetch/blackout-core/analytics',
+  const original = jest.requireActual(
+    '@farfetch/blackout-react-native-analytics',
   );
 
-  const originalScreenTypes = jest.requireActual(
-    '@farfetch/blackout-react-native-analytics/src/screenTypes',
-  ).default;
-
   return {
-    ...originalAnalyticsCore,
-    screenTypes: originalScreenTypes,
+    ...original,
     utils: {
       logger: {
         error: jest.fn(),


### PR DESCRIPTION
## Description

- This fixes the wrong import path for Integration class as it was
importing from `integrations` which does not exist now.
- Fixed tests and applied an alias in jest.config for
@farfetch/blackout-react-native-analytics package.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)