### PR TITLE
fix(analytics): fix bugs with `basic` mode in FirebaseAnalytics

### DIFF
--- a/packages/react-native-analytics/src/integrations/firebaseAnalytics/FirebaseAnalytics.js
+++ b/packages/react-native-analytics/src/integrations/firebaseAnalytics/FirebaseAnalytics.js
@@ -51,7 +51,7 @@ class FirebaseAnalytics extends Integration {
    * @param {object} options - User configured options.
    * @param {object} loadData - Analytics' load event data.
    */
-  constructor(options = {}, loadData) {
+  constructor(options = {}, loadData = {}) {
     super(options, loadData);
 
     checkRNFirebaseAnalyticsInstalled();
@@ -62,6 +62,9 @@ class FirebaseAnalytics extends Integration {
     this.googleConsentConfigWithoutMode = omit(this.googleConsentConfig, [
       'mode',
     ]);
+
+    // Call setConsent so that consent mode is persisted
+    this.setConsent(loadData.consent);
   }
 
   /**
@@ -384,7 +387,7 @@ class FirebaseAnalytics extends Integration {
    * @param {object} consentData - Consent object containing the user consent.
    */
   async setConsent(consentData) {
-    if (this.googleConsentConfigWithoutMode) {
+    if (this.googleConsentConfigWithoutMode && consentData) {
       // Dealing with null or undefined consent values
       const safeConsent = consentData || {};
 
@@ -415,7 +418,8 @@ class FirebaseAnalytics extends Integration {
       // will only be called if the integration was loaded, i.e., the
       // statistics consent was given.
       if (
-        get(this.options, `${OPTION_GOOGLE_CONSENT_CONFIG}.mode`) === 'Basic'
+        get(this.options, `${OPTION_GOOGLE_CONSENT_CONFIG}.mode`, 'Basic') ===
+        'Basic'
       ) {
         await firebaseAnalytics().setAnalyticsCollectionEnabled(true);
       }

--- a/packages/react-native-analytics/src/integrations/firebaseAnalytics/__tests__/FirebaseAnalytics.test.js
+++ b/packages/react-native-analytics/src/integrations/firebaseAnalytics/__tests__/FirebaseAnalytics.test.js
@@ -126,6 +126,23 @@ describe('FirebaseAnalyticsIntegration integration', () => {
 });
 
 describe('FirebaseAnalyticsIntegration instance', () => {
+  describe('constructor', () => {
+    it('should call setConsent', () => {
+      const spy = jest.spyOn(
+        FirebaseAnalyticsIntegration.prototype,
+        'setConsent',
+      );
+
+      const loadData = {
+        consent: { marketing: true, preferences: true, statistics: true },
+      };
+
+      createInstance(undefined, loadData);
+
+      expect(spy).toHaveBeenCalledWith(loadData.consent);
+    });
+  });
+
   describe(`${OPTION_SCREEN_VIEWS_MAPPER} option`, () => {
     it('Should allow to add/override custom screen view mappers', () => {
       const mockCustomScreenViewMapperFunction = jest.fn();
@@ -1016,7 +1033,6 @@ describe('FirebaseAnalyticsIntegration instance', () => {
             ad_personalization: { categories: ['marketing'] },
             analytics_storage: { categories: ['marketing'] },
             ad_storage: { categories: ['marketing'] },
-            mode: 'Basic',
           },
         });
 
@@ -1036,7 +1052,7 @@ describe('FirebaseAnalyticsIntegration instance', () => {
     });
 
     describe('When in advanced mode', () => {
-      it('should not call `setAnalyticsCollectionEnabled` in setConsent', async () => {
+      it('should not call `setAnalyticsCollectionEnabled` in setConsent but should call `setConsent` from firebase analytics if consent is not null', async () => {
         const instance = createInstance({
           [OPTION_GOOGLE_CONSENT_CONFIG]: {
             ad_user_data: { categories: ['marketing'] },
@@ -1055,6 +1071,26 @@ describe('FirebaseAnalyticsIntegration instance', () => {
           ad_user_data: true,
           analytics_storage: true,
         });
+
+        expect(
+          firebaseAnalytics().setAnalyticsCollectionEnabled,
+        ).not.toHaveBeenCalled();
+      });
+
+      it('should not call both `setAnalyticsCollectionEnabled` and `setConsent` from firebase analytics in setConsent if consent is null', async () => {
+        const instance = createInstance({
+          [OPTION_GOOGLE_CONSENT_CONFIG]: {
+            ad_user_data: { categories: ['marketing'] },
+            ad_personalization: { categories: ['marketing'] },
+            analytics_storage: { categories: ['marketing'] },
+            ad_storage: { categories: ['marketing'] },
+            mode: 'Advanced',
+          },
+        });
+
+        await instance.setConsent(null);
+
+        expect(firebaseAnalytics().setConsent).not.toHaveBeenCalled();
 
         expect(
           firebaseAnalytics().setAnalyticsCollectionEnabled,


### PR DESCRIPTION
## Description

This fixes a bug that happens in FirebaseAnalytics integration when its `mode` option is set to `Basic` and a call to `analytics.setConsent` is done later, the integration's own `setConsent` method is not being called which prevents the sending of the google consent mode values to firebase. Also, this fixes the check for the call to firebaseAnalytics().setAnalyticsCollectionEnabled to assume `Basic` as the default value for `mode` if none exists.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)